### PR TITLE
feat: Allow login with email and update user details

### DIFF
--- a/task_gamification_app/app/cli.py
+++ b/task_gamification_app/app/cli.py
@@ -73,7 +73,7 @@ def login_user():
     db = get_db_session()
     try:
         # Use the service function to verify login
-        user_obj = verify_user_login_service(db_session=db, username=username, password=password)
+        user_obj = verify_user_login_service(db_session=db, username_or_email=username, password=password)
         if user_obj:
             CURRENT_USER_ID = user_obj.id
             print(f"Welcome, {username}! You are now logged in.")

--- a/task_gamification_app/app/services.py
+++ b/task_gamification_app/app/services.py
@@ -61,12 +61,12 @@ def create_user(db_session: Session, username: str, email: str, password: str) -
         raise UserCreationError(f"An unexpected error occurred during user creation: {e}")
 
 
-def verify_user_login(db_session: Session, username: str, password: str) -> Union[User, None]:
+def verify_user_login(db_session: Session, username_or_email: str, password: str) -> Union[User, None]:
     """
     Verifies user credentials.
     Returns the User object if login is successful, None otherwise.
     """
-    user = db_session.query(User).filter(User.username == username).first()
+    user = db_session.query(User).filter((User.username == username_or_email) | (User.email == username_or_email)).first()
     if user and user.check_password(password):
         return user
     return None

--- a/task_gamification_app/webapp/forms.py
+++ b/task_gamification_app/webapp/forms.py
@@ -44,7 +44,7 @@ class ResetPasswordForm(FlaskForm):
     submit = SubmitField('Reset Password')
 
 class LoginForm(FlaskForm):
-    username = StringField('Username', validators=[DataRequired()])
+    username_or_email = StringField('Username or Email', validators=[DataRequired()])
     # email = StringField('Email', validators=[DataRequired(), Email()]) # If logging in with email
     password = PasswordField('Password', validators=[DataRequired()])
     remember = BooleanField('Remember Me') # Optional: for "remember me" functionality
@@ -77,6 +77,7 @@ class UpdateTaskForm(TaskForm):
 
 class EditUserForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired(), Length(min=2, max=20)])
+    email = StringField('Email', validators=[DataRequired(), Email()])
     submit = SubmitField('Update')
 
 class AddEmailForm(FlaskForm):

--- a/task_gamification_app/webapp/routes.py
+++ b/task_gamification_app/webapp/routes.py
@@ -90,7 +90,7 @@ def login():
             db_session = SessionLocal()
             user = verify_user_login_service(
                 db_session=db_session,
-                username=form.username.data,
+                username_or_email=form.username_or_email.data,
                 password=form.password.data
             )
             if user:
@@ -351,7 +351,8 @@ def edit_user():
             updated_user = update_user_service(
                 db_session=db_session,
                 user_id=user_id,
-                username=form.username.data
+                username=form.username.data,
+                email=form.email.data
             )
             session['username'] = updated_user.username
             flash('Your details have been updated.', 'success')


### PR DESCRIPTION
This commit introduces the following changes:

- Users can now log in using either their username or email address.
- The login form has been updated to reflect this change.
- Users can now edit their username and email address from their profile.
- The edit user form and route have been updated to support this functionality.